### PR TITLE
Fix/showing restricted paths

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,9 +1,14 @@
 # BEGIN WordPress
-# The directives (lines) between `BEGIN WordPress` and `END WordPress` are
+
+# The directives (lines) between "BEGIN WordPress" and "END WordPress" are
+
 # dynamically generated, and should only be modified via WordPress filters.
+
 # Any changes to the directives between these markers will be overwritten.
+
 <IfModule mod_rewrite.c>
 RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 RewriteBase /
 RewriteRule ^index\.php$ - [L]
 RewriteCond %{REQUEST_FILENAME} !-f
@@ -12,18 +17,3 @@ RewriteRule . /index.php [L]
 </IfModule>
 
 # END WordPress
-
-# BEGIN Electric Book WP
-<IfModule mod_rewrite.c>
-RewriteEngine On
-RewriteCond %{REQUEST_URI} \.(?:html|htm)$ [NC]
-RewriteCond %{REQUEST_FILENAME} doing-economics
-RewriteRule . /index.php?electric-book-wp-restricted-path=doing-economics&electric-book-wp-serve=%{REQUEST_URI} [L]
-</IfModule>
-<IfModule mod_rewrite.c>
-RewriteEngine On
-RewriteCond %{REQUEST_FILENAME} doing-economics
-RewriteCond %{HTTP_REFERER} \.(gif|jpeg|jpg|png|svg|bmp|mov|webp|css|js)$ [NC]
-RewriteRule . /index.php?error=404
-</IfModule>
-# END Electric Book WP

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The base configuration for WordPress
  *
@@ -20,22 +21,22 @@
 
 // ** MySQL settings - You can get this info from your web host ** //
 /** The name of the database for WordPress */
-define( 'DB_NAME', 'ebwp.demo');
+define('DB_NAME', 'ebwp.demo');
 
 /** MySQL database username */
-define( 'DB_USER', 'dev');
+define('DB_USER', 'dev');
 
 /** MySQL database password */
-define( 'DB_PASSWORD', 'dev');
+define('DB_PASSWORD', 'dev');
 
 /** MySQL hostname */
-define( 'DB_HOST', 'db');
+define('DB_HOST', 'db');
 
 /** Database Charset to use in creating database tables. */
-define( 'DB_CHARSET', 'utf8');
+define('DB_CHARSET', 'utf8');
 
 /** The Database Collate type. Don't change this if in doubt. */
-define( 'DB_COLLATE', '');
+define('DB_COLLATE', '');
 
 /**#@+
  * Authentication Unique Keys and Salts.
@@ -46,14 +47,14 @@ define( 'DB_COLLATE', '');
  *
  * @since 2.6.0
  */
-define( 'AUTH_KEY',         'e1d59636c403f8f02d1ebd0f50e2347ca8739c09');
-define( 'SECURE_AUTH_KEY',  '6565f3fa98fbf2537cf0d23e92990d6d4e453960');
-define( 'LOGGED_IN_KEY',    '251ef2d87a8d52cf5d04e79009363f1b6f55ab68');
-define( 'NONCE_KEY',        '52432acfbbabaa3ee663aeca10966b8848e53544');
-define( 'AUTH_SALT',        'e70639cd93c05dccf1f4610cd331a20e11841125');
-define( 'SECURE_AUTH_SALT', '28f879871a8893401e2ce44cd976c18e8675ab81');
-define( 'LOGGED_IN_SALT',   '7638cfc1001d402677f6d3a0df4102f444181967');
-define( 'NONCE_SALT',       '9e5558944c223ce7e17b67bdaa0c2803900a74a0');
+define('AUTH_KEY',         'e1d59636c403f8f02d1ebd0f50e2347ca8739c09');
+define('SECURE_AUTH_KEY',  '6565f3fa98fbf2537cf0d23e92990d6d4e453960');
+define('LOGGED_IN_KEY',    '251ef2d87a8d52cf5d04e79009363f1b6f55ab68');
+define('NONCE_KEY',        '52432acfbbabaa3ee663aeca10966b8848e53544');
+define('AUTH_SALT',        'e70639cd93c05dccf1f4610cd331a20e11841125');
+define('SECURE_AUTH_SALT', '28f879871a8893401e2ce44cd976c18e8675ab81');
+define('LOGGED_IN_SALT',   '7638cfc1001d402677f6d3a0df4102f444181967');
+define('NONCE_SALT',       '9e5558944c223ce7e17b67bdaa0c2803900a74a0');
 
 /**#@-*/
 
@@ -93,9 +94,9 @@ define('WP_DEFAULT_THEME', 'serve-restricted-html');
 /* That's all, stop editing! Happy publishing. */
 
 /** Absolute path to the WordPress directory. */
-if ( ! defined( 'ABSPATH' ) ) {
-	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+if (!defined('ABSPATH')) {
+	define('ABSPATH', dirname(__FILE__) . '/');
 }
 
 /** Sets up WordPress vars and included files. */
-require_once( ABSPATH . 'wp-settings.php' );
+require_once(ABSPATH . 'wp-settings.php');

--- a/wp-content/plugins/electric-book-wp/includes/delete-restricted-path.php
+++ b/wp-content/plugins/electric-book-wp/includes/delete-restricted-path.php
@@ -2,14 +2,16 @@
 
 defined('ABSPATH') || exit;
 
-function electric_book_wp_delete_restricted_path() {
+function electric_book_wp_delete_restricted_path()
+{
   if (isset($_POST['delete_restricted_path']) && !empty($_POST['delete_restricted_path'])) {
     $restrict_path_key = '"' . esc_attr(stripslashes($_POST['delete_restricted_path'])) . '"';
     $restrict_options_all = get_option('electric_book_wp_restrict_all');
+    $restricted_path_string = $restrict_options_all[$restrict_path_key]['path'];
     unset($restrict_options_all[$restrict_path_key]);
     $restrict_options_all_updated = update_option('electric_book_wp_restrict_all', $restrict_options_all);
     if ($restrict_options_all_updated) {
-      electric_book_wp_htaccess_restricted_paths();
+      electric_book_wp_htaccess_restricted_paths('delete', $restricted_path_string);
       add_settings_error('electric_book_wp_messages', 'electric_book_wp_message', __('Restricted path setting deleted', 'electric_book_wp'), 'success');
     }
   }

--- a/wp-content/plugins/electric-book-wp/includes/htaccess-restricted-paths.php
+++ b/wp-content/plugins/electric-book-wp/includes/htaccess-restricted-paths.php
@@ -2,63 +2,43 @@
 
 defined('ABSPATH') || exit;
 
-function electric_book_wp_htaccess_restricted_paths() {
+function electric_book_wp_htaccess_restricted_paths($action = null, $pathPassed = null)
+{
+
   $begin_Comment = "\n" . '# BEGIN Electric Book WP' . "\n";
   $end_Comment = '# END Electric Book WP' . "\n";
 
-  $htaccess_path = ABSPATH . '/.htaccess';
-  $htaccess_content = file_get_contents($htaccess_path);
-
-  $restrict_options_all = get_option('electric_book_wp_restrict_all');
-  $has_saved_paths = !empty($restrict_options_all) && is_array($restrict_options_all);
-
-  if ($has_saved_paths) {
-
-    $path_rules = '';
-    // generate saved paths
-    foreach ($restrict_options_all as $path) {
-      $path_rules .= '<IfModule mod_rewrite.c>' . "\n";
-      $path_rules .= 'RewriteEngine On' . "\n";
-      $path_rules .= 'RewriteCond %{REQUEST_FILENAME} ' . $path['path'] . "\n";
-      // serve the html via PHP
-      $path_rules .= 'RewriteRule . /index.php?electric-book-wp-restricted-path=' . $path['path'] . '&electric-book-wp-serve=%{REQUEST_URI} [L]' . "\n";
-      $path_rules .= '</IfModule>' . "\n";
-    }
-
-    $rules = $begin_Comment;
-
-    // print out saved paths
-    $rules .= $path_rules;
-
-    // Have to forbid direct access to asset files at restricted urls regardless of logged-in status.
-    // This is due to fileread() restrictions when handed over to PHP.
-    $asset_rules = '';
-    foreach ($restrict_options_all as $path) {
-      $asset_rules .= '<IfModule mod_rewrite.c>' . "\n";
-      $asset_rules .= 'RewriteEngine On' . "\n";
-      $asset_rules .= 'RewriteCond %{REQUEST_FILENAME} ' . $path['path'] . "\n";
-      $asset_rules .= 'RewriteCond %{HTTP_REFERER} \.(gif|jpeg|jpg|png|svg|bmp|mov|webp|css|js)$ [NC]' . "\n";
-      $asset_rules .= 'RewriteRule . /index.php?error=404' . "\n";
-      $asset_rules .= '</IfModule>' . "\n";
-    }
-
-    // print out saved paths
-    $rules .= $asset_rules;
-
-    $rules .= $end_Comment;
-
-    if (strpos($htaccess_content, $begin_Comment) !== false) {
-      $existing_rules = between($begin_Comment, $end_Comment, $htaccess_content);
-      $htaccess_content_updated = str_replace($begin_Comment . $existing_rules . $end_Comment, $rules, $htaccess_content);
-      file_put_contents($htaccess_path, $htaccess_content_updated);
-    } else {
-      file_put_contents($htaccess_path, $rules, FILE_APPEND | LOCK_EX);
-    }
-
-  } else {
+  if ($action === 'delete' && $pathPassed) {
+    $htaccess_path = ABSPATH . '/' . $pathPassed . '/.htaccess';
+    $htaccess_content = file_get_contents($htaccess_path);
     $existing_rules = between($begin_Comment, $end_Comment, $htaccess_content);
     $htaccess_content_updated = str_replace($begin_Comment . $existing_rules . $end_Comment, '', $htaccess_content);
     file_put_contents($htaccess_path, $htaccess_content_updated);
+  } else {
+    $restrict_options_all = get_option('electric_book_wp_restrict_all');
+    $has_saved_paths = !empty($restrict_options_all) && is_array($restrict_options_all);
+    if ($has_saved_paths) {
+      // create htaccess file/rules for each path
+      foreach ($restrict_options_all as $path) {
+        $htaccess_path = ABSPATH . '/' . $path['path'] . '/.htaccess';
+        $htaccess_content = file_get_contents($htaccess_path);
+        $rules = $begin_Comment;
+        // serve the html via PHP
+        $path_rules = '<IfModule mod_rewrite.c>' . "\n";
+        $path_rules .= 'RewriteEngine On' . "\n";
+        $path_rules .= 'RewriteRule . /index.php?electric-book-wp-restricted-path=' . $path['path'] . '&electric-book-wp-serve=%{REQUEST_URI} [L]' . "\n";
+        $path_rules .= '</IfModule>' . "\n";
+        $rules .= $path_rules;
+        $rules .= $end_Comment;
+        // Add rules to htaccess file. If one doesn't exist one will be created.
+        if (strpos($htaccess_content, $begin_Comment) !== false) {
+          $existing_rules = between($begin_Comment, $end_Comment, $htaccess_content);
+          $htaccess_content_updated = str_replace($begin_Comment . $existing_rules . $end_Comment, $rules, $htaccess_content);
+          file_put_contents($htaccess_path, $htaccess_content_updated);
+        } else {
+          file_put_contents($htaccess_path, $rules, FILE_APPEND | LOCK_EX);
+        }
+      }
+    }
   }
-
 }

--- a/wp-content/plugins/electric-book-wp/includes/serve-restricted-html.php
+++ b/wp-content/plugins/electric-book-wp/includes/serve-restricted-html.php
@@ -2,7 +2,8 @@
 
 defined('ABSPATH') || exit;
 
-function electric_book_wp_can_user_view($current_setting) {
+function electric_book_wp_can_user_view($current_setting)
+{
   $can_they = false;
   $user = wp_get_current_user();
   if (!empty($current_setting['roles'])) {
@@ -17,7 +18,8 @@ function electric_book_wp_can_user_view($current_setting) {
   return $can_they;
 }
 
-function electric_book_wp_serve_restricted_html($get_restricted_path) {
+function electric_book_wp_serve_restricted_html($get_restricted_path)
+{
   $restrict_options_all = get_option('electric_book_wp_restrict_all');
   $current_setting = $restrict_options_all['"' . $get_restricted_path . '"'];
   $requested_url = $_GET['electric-book-wp-serve'];
@@ -25,7 +27,7 @@ function electric_book_wp_serve_restricted_html($get_restricted_path) {
     $requested_url .= '/index.html';
   }
   $mime_type = mime_content_type(ABSPATH . $requested_url);
-  if (is_user_logged_in() && electric_book_wp_can_user_view($current_setting) && $mime_type == 'text/html') {
+  if (is_user_logged_in() && electric_book_wp_can_user_view($current_setting)) {
     header('Content-Type: ' . $mime_type);
     readfile(ABSPATH . $requested_url);
   } elseif (is_user_logged_in()) {
@@ -48,7 +50,8 @@ function electric_book_wp_serve_restricted_html($get_restricted_path) {
   exit;
 }
 
-function electric_book_wp_check_incoming() {
+function electric_book_wp_check_incoming()
+{
   $get_restricted_path = isset($_GET['electric-book-wp-restricted-path']) && !empty($_GET['electric-book-wp-restricted-path']) ? $_GET['electric-book-wp-restricted-path'] : false;
   if ($get_restricted_path !== false) {
     electric_book_wp_serve_restricted_html($get_restricted_path);

--- a/wp-content/plugins/electric-book-wp/wp-electric-book.php
+++ b/wp-content/plugins/electric-book-wp/wp-electric-book.php
@@ -159,8 +159,14 @@ function electric_book_wp_restrict_options_page_html()
     // remove leading and trailing slashes
     $restrict_path_added = trim($restrict_path_added, '/');
 
+    // check path exists and doesn't coflict with any WP URIs in DB
+    $restrict_path_added_abspath = ABSPATH . '/' . $restrict_path_added;
+    $file_folder_exists = file_exists($restrict_path_added_abspath) || is_dir($restrict_path_added_abspath);
+    $is_wp_uri = get_page_by_path($restrict_path_added, OBJECT, ['page', 'post']);
+
     $restricted_path_url = get_option('siteurl') . '/' .  $restrict_path_added;
-    if (!empty($restrict_path_added) && filter_var($restricted_path_url, FILTER_VALIDATE_URL)) {
+
+    if (!empty($restrict_path_added) && $file_folder_exists && !$is_wp_uri && filter_var($restricted_path_url, FILTER_VALIDATE_URL)) {
       $saved_restricted_roles = array();
       foreach ($restrict_options as $key => $option) {
         if (startsWith($electric_book_wp_field_roles_id, $key)) {
@@ -188,7 +194,7 @@ function electric_book_wp_restrict_options_page_html()
         add_settings_error('electric_book_wp_messages', 'electric_book_wp_message', __('That particular restricted path setting already exists. No changes to existing settings were made.', 'electric_book_wp'), 'info');
       }
     } else {
-      add_settings_error('electric_book_wp_messages', 'electric_book_wp_message', __('A valid path value has not been entered', 'electric_book_wp'), 'error');
+      add_settings_error('electric_book_wp_messages', 'electric_book_wp_message', __('A valid path value has not been entered or it conflicts with an existing WordPress permalink.', 'electric_book_wp'), 'error');
     }
   }
 

--- a/wp-content/plugins/electric-book-wp/wp-electric-book.php
+++ b/wp-content/plugins/electric-book-wp/wp-electric-book.php
@@ -1,8 +1,9 @@
 <?php
+
 /**
  * Plugin Name:       Electric Book WP
  * Description:       Manage static HTML publications inside WordPress
- * Version:           1.0.0
+ * Version:           2.0.0
  * License:           GPL v2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  */
@@ -26,7 +27,8 @@ $electric_book_wp_field_path_id = 'restrict_path';
 $electric_book_wp_field_roles_id = 'restrict_roles';
 $electric_book_wp_field_redirect_id = 'restrict_redirect';
 
-function electric_book_wp_settings_init() {
+function electric_book_wp_settings_init()
+{
 
   global $electric_book_wp_field_path_id, $electric_book_wp_field_roles_id, $electric_book_wp_field_redirect_id;
 
@@ -72,32 +74,35 @@ function electric_book_wp_settings_init() {
       'label_for' => $electric_book_wp_field_redirect_id
     ]
   );
-
 }
 
 add_action('admin_init', 'electric_book_wp_settings_init');
 
 // restrict section callback
 // $args is the last parameter defined by add_settings_section()
-function electric_book_wp_section_restrict_access_cb($args) { ?>
+function electric_book_wp_section_restrict_access_cb($args)
+{ ?>
   <p>Paths should be relative to the root of your WordPress installation. A path to a directory will automatically include all subdirectories and files inside it.</p>
 <?php }
 
 // restrict section field callbacks
 // $args is the last parameter defined by add_settings_field()
-function electric_book_wp_field_restrict_path_cb($args) { ?>
-  <input id="<?=esc_attr($args['label_for'])?>" type="text" name="electric_book_wp_restrict[<?=esc_attr($args['label_for'])?>]" placeholder="your/path/goes/here.html" class="regular-text">
-<?php }
+function electric_book_wp_field_restrict_path_cb($args)
+{ ?>
+  <input id="<?= esc_attr($args['label_for']) ?>" type="text" name="electric_book_wp_restrict[<?= esc_attr($args['label_for']) ?>]" placeholder="your/path/goes/here.html" class="regular-text">
+  <?php }
 
-function electric_book_wp_field_restrict_roles_cb($args) {
+function electric_book_wp_field_restrict_roles_cb($args)
+{
   global $wp_roles;
   foreach ($wp_roles->roles as $key => $role) { ?>
-    <p><label><input type="checkbox" name="electric_book_wp_restrict[<?=esc_attr($args['label_for']) . '_' . esc_attr($key)?>]" value="<?=esc_attr($key)?>"><?=$role['name']?></label></p>
+    <p><label><input type="checkbox" name="electric_book_wp_restrict[<?= esc_attr($args['label_for']) . '_' . esc_attr($key) ?>]" value="<?= esc_attr($key) ?>"><?= $role['name'] ?></label></p>
   <?php }
 }
 
-function electric_book_wp_field_restrict_redirect_cb($args) { ?>
-  <input id="<?=esc_attr($args['label_for'])?>" type="text" name="electric_book_wp_restrict[<?=esc_attr($args['label_for'])?>]" placeholder="E.g. '/custom-file.php' or '/custom/page/'" class="regular-text">
+function electric_book_wp_field_restrict_redirect_cb($args)
+{ ?>
+  <input id="<?= esc_attr($args['label_for']) ?>" type="text" name="electric_book_wp_restrict[<?= esc_attr($args['label_for']) ?>]" placeholder="E.g. '/custom-file.php' or '/custom/page/'" class="regular-text">
   <p>Leave blank to redirect to the WordPress login page. The path provided must either be relative to the root of your site or an absolute URL.</p>
   <p>Two GET parameters will be passed to your custom page:</p>
   <ol>
@@ -109,7 +114,8 @@ function electric_book_wp_field_restrict_redirect_cb($args) { ?>
 /**
  * Create settings menu item
  */
-function electric_book_wp_restrict_options_page() {
+function electric_book_wp_restrict_options_page()
+{
   // add top level menu page
   add_menu_page(
     'Electric Book WP',
@@ -126,7 +132,8 @@ add_action('admin_menu', 'electric_book_wp_restrict_options_page');
 /**
  * Create settings page via callback from add_menu_page()
  */
-function electric_book_wp_restrict_options_page_html() {
+function electric_book_wp_restrict_options_page_html()
+{
 
   global $wp_roles, $electric_book_wp_field_path_id, $electric_book_wp_field_roles_id, $electric_book_wp_field_redirect_id;
 
@@ -155,7 +162,7 @@ function electric_book_wp_restrict_options_page_html() {
     $restricted_path_url = get_option('siteurl') . '/' .  $restrict_path_added;
     if (!empty($restrict_path_added) && filter_var($restricted_path_url, FILTER_VALIDATE_URL)) {
       $saved_restricted_roles = array();
-      foreach($restrict_options as $key => $option) {
+      foreach ($restrict_options as $key => $option) {
         if (startsWith($electric_book_wp_field_roles_id, $key)) {
           array_push($saved_restricted_roles, $option);
         }
@@ -180,7 +187,6 @@ function electric_book_wp_restrict_options_page_html() {
       } else {
         add_settings_error('electric_book_wp_messages', 'electric_book_wp_message', __('That particular restricted path setting already exists. No changes to existing settings were made.', 'electric_book_wp'), 'info');
       }
-
     } else {
       add_settings_error('electric_book_wp_messages', 'electric_book_wp_message', __('A valid path value has not been entered', 'electric_book_wp'), 'error');
     }
@@ -188,7 +194,7 @@ function electric_book_wp_restrict_options_page_html() {
 
   // show error/update messages
   settings_errors('electric_book_wp_messages');
-  ?>
+?>
   <div class="wrap">
     <h1><?php echo esc_html(get_admin_page_title()); ?></h1>
     <form action="options.php" method="post">
@@ -206,27 +212,27 @@ function electric_book_wp_restrict_options_page_html() {
       <hr>
       <h2>Saved restricted paths</h2>
       <form method="post">
-      <?php
-      foreach ($restrict_options_all as $key => $path) {
-        $path_properties = $path; ?>
-        <p>Restricted path: <?=esc_html($path_properties['path'])?></p>
-        <p>Permitted user roles:
-          <?php
-          if (empty($path_properties['roles'])) {
-            echo 'All';
-          } else {
-            foreach ($path_properties['roles'] as $role) {
-              echo $wp_roles->roles[$role]['name'] . ', ';
-            }
-          } ?>
-        </p>
-        <p>Redirect to: <code><?= isset($path['redirect']) ? $path['redirect'] : 'wp-login.php'?></code></p>
-        <p><button type="submit" value="<?=esc_attr($path_properties['path'])?>" name="delete_restricted_path">Delete</button></p>
-        <hr>
-      <?php } ?>
+        <?php
+        foreach ($restrict_options_all as $key => $path) {
+          $path_properties = $path; ?>
+          <p>Restricted path: <?= esc_html($path_properties['path']) ?></p>
+          <p>Permitted user roles:
+            <?php
+            if (empty($path_properties['roles'])) {
+              echo 'All';
+            } else {
+              foreach ($path_properties['roles'] as $role) {
+                echo $wp_roles->roles[$role]['name'] . ', ';
+              }
+            } ?>
+          </p>
+          <p>Redirect to: <code><?= isset($path['redirect']) ? $path['redirect'] : 'wp-login.php' ?></code></p>
+          <p><button type="submit" value="<?= esc_attr($path_properties['path']) ?>" name="delete_restricted_path">Delete</button></p>
+          <hr>
+        <?php } ?>
       </form>
     <?php } ?>
 
   </div>
-  <?php
+<?php
 }


### PR DESCRIPTION
Hi @arthurattwell 

Apologies about all the formatting changes that dirty the diff a bit. My code editor got a bit carried away.

But I think it is still reasonably easy enough to see the pertinent changes.

I've test pretty thoroughly and it all seems to be a lot more robust (and simpler).

I've disallowed the addition of paths that don't exists and if a path is already a registered WP URI.

<img width="658" alt="Screenshot 2023-03-21 at 11 48 46" src="https://user-images.githubusercontent.com/188279/226572020-ea4ec55a-47fb-466f-8b18-9bd30dd9366c.png">

When updating production (and other instances), you'll need to manually clean up the htaccess in the root. I didn't cater for this legacy clean up, but I can if you would like me to. Just let me know.
