### PR TITLE
Enforce site url as host for restricted static paths

### DIFF
--- a/wp-content/plugins/electric-book-wp/includes/htaccess-restricted-paths.php
+++ b/wp-content/plugins/electric-book-wp/includes/htaccess-restricted-paths.php
@@ -27,6 +27,11 @@ function electric_book_wp_htaccess_restricted_paths($action = null, $pathPassed 
         $path_rules = '<IfModule mod_rewrite.c>' . "\n";
         $path_rules .= 'RewriteEngine On' . "\n";
         $path_rules .= 'RewriteCond %{REQUEST_URI} \.(?:html|htm)$ [NC]' . "\n";
+        $path_rules .= 'RewriteRule . ' . get_site_url() . '/$1 [R=301]' . "\n";
+        $path_rules .= '</IfModule>' . "\n";
+        $path_rules .= '<IfModule mod_rewrite.c>' . "\n";
+        $path_rules .= 'RewriteEngine On' . "\n";
+        $path_rules .= 'RewriteCond %{REQUEST_URI} \.(?:html|htm)$ [NC]' . "\n";
         $path_rules .= 'RewriteRule . /index.php?electric-book-wp-restricted-path=' . $path['path'] . '&electric-book-wp-serve=%{REQUEST_URI} [L]' . "\n";
         $path_rules .= '</IfModule>' . "\n";
         $rules .= $path_rules;

--- a/wp-content/plugins/electric-book-wp/wp-electric-book.php
+++ b/wp-content/plugins/electric-book-wp/wp-electric-book.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name:       Electric Book WP
  * Description:       Manage static HTML publications inside WordPress
- * Version:           2.0.0
+ * Version:           2.1.0
  * License:           GPL v2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  */
@@ -74,6 +74,9 @@ function electric_book_wp_settings_init()
       'label_for' => $electric_book_wp_field_redirect_id
     ]
   );
+
+  // run htaccess writer on initialisation to clean up legacy rules and to make sure site URL is up to date
+  electric_book_wp_htaccess_restricted_paths();
 }
 
 add_action('admin_init', 'electric_book_wp_settings_init');


### PR DESCRIPTION
Hi @arthurattwell 

I was able to replicate the issue locally this morning. This means I was able to successfully test this fix.

The issue is that if the host 301 rewrite rule is applied when PHP adding it to its output, the document isn't served and parsed correctly.

So, as suspected, forcing a 301 to the site's defined URL prior to restricted path rewrites works.

I've pushed this up so that you can test it on production or elsewhere as soon as you are ready to without waiting until next week, but there are some things I'd like to add to this update, namely:

1. Hook into changes to the site URL setting in WordPress, so if this is changed the .htaccess files get updated.
2. Legacy update. Check if the new rules have been applied to all .htaccess files. If not, apply them. (You can let me know if this feature is necessary.)

I'm just a bit short on time today, so in the meantime to test this update, just make sure to delete and re-add the restricted paths under the plugin settings, or manually update the .htaccess files yourself (change `https://www.core-econ.org` to relevant domain, and `test-bank` to relevant path):

```
# BEGIN Electric Book WP
<IfModule mod_rewrite.c>
RewriteEngine On
RewriteCond %{REQUEST_URI} \.(?:html|htm)$ [NC]
RewriteRule . https://www.core-econ.org/$1 [R=301]
</IfModule>
<IfModule mod_rewrite.c>
RewriteEngine On
RewriteCond %{REQUEST_URI} \.(?:html|htm)$ [NC]
RewriteRule . /index.php?electric-book-wp-restricted-path=test-bank&electric-book-wp-serve=%{REQUEST_URI} [L]
</IfModule>
# END Electric Book WP

```

