### PR TITLE
Revert "Allow global access to restricted HTML via Basic auth"

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -91,10 +91,6 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 define('WP_DEFAULT_THEME', 'serve-restricted-html');
 
-// Basic auth credentials for access to all resticted HTML regardless of WP user status
-define('ELECTRIC_BOOK_WP_BASIC_AUTH_USER', 'ebwpclient');
-define('ELECTRIC_BOOK_WP_BASIC_AUTH_PW', 'pV0zIfE13b%$');
-
 /* That's all, stop editing! Happy publishing. */
 
 /** Absolute path to the WordPress directory. */

--- a/wp-content/plugins/electric-book-wp/includes/serve-restricted-html.php
+++ b/wp-content/plugins/electric-book-wp/includes/serve-restricted-html.php
@@ -2,35 +2,18 @@
 
 defined('ABSPATH') || exit;
 
-function electric_book_wp_basic_auth()
-{
-  $AUTH_USER = ELECTRIC_BOOK_WP_BASIC_AUTH_USER;
-  $AUTH_PASS = ELECTRIC_BOOK_WP_BASIC_AUTH_PW;
-  header('Cache-Control: no-cache, must-revalidate, max-age=0');
-  $has_supplied_credentials = !(empty($_SERVER['PHP_AUTH_USER']) && empty($_SERVER['PHP_AUTH_PW']));
-  $is_not_authenticated = (!$has_supplied_credentials ||
-    $_SERVER['PHP_AUTH_USER'] != $AUTH_USER ||
-    $_SERVER['PHP_AUTH_PW']   != $AUTH_PASS
-  );
-  return !$is_not_authenticated;
-}
-
 function electric_book_wp_can_user_view($current_setting)
 {
   $can_they = false;
-  if (electric_book_wp_basic_auth()) {
-    $can_they = true;
-  } elseif (is_user_logged_in()) {
-    $user = wp_get_current_user();
-    if (!empty($current_setting['roles'])) {
-      foreach ($current_setting['roles'] as $role) {
-        if (in_array($role, (array) $user->roles)) {
-          $can_they = true;
-        }
+  $user = wp_get_current_user();
+  if (!empty($current_setting['roles'])) {
+    foreach ($current_setting['roles'] as $role) {
+      if (in_array($role, (array) $user->roles)) {
+        $can_they = true;
       }
-    } else {
-      $can_they = true;
     }
+  } else {
+    $can_they = true;
   }
   return $can_they;
 }
@@ -44,7 +27,7 @@ function electric_book_wp_serve_restricted_html($get_restricted_path)
     $requested_url .= '/index.html';
   }
   $mime_type = mime_content_type(ABSPATH . $requested_url);
-  if (electric_book_wp_can_user_view($current_setting)) {
+  if (is_user_logged_in() && electric_book_wp_can_user_view($current_setting)) {
     header('Content-Type: ' . $mime_type);
     readfile(ABSPATH . $requested_url);
   } elseif (is_user_logged_in()) {


### PR DESCRIPTION
Reverts electricbookworks/electric-book-wp#17

While we're not 100% it's the cause, restricted pages are not getting CSS on production, so I'm rolling this back for now. We're considering alternative approaches.