### PR TITLE
Restrict entire terminal directory

### DIFF
--- a/wp-content/plugins/electric-book-wp/includes/htaccess-restricted-paths.php
+++ b/wp-content/plugins/electric-book-wp/includes/htaccess-restricted-paths.php
@@ -20,9 +20,10 @@ function electric_book_wp_htaccess_restricted_paths($action = null, $pathPassed 
     if ($has_saved_paths) {
       // create htaccess file/rules for each path
       foreach ($restrict_options_all as $path) {
-        $htaccess_path = ABSPATH . '/' . $path['path'] . '/.htaccess';
+        $path = endsWith('html', $path['path']) || endsWith('htm', $path['path']) ? dirname($path['path']) : $path['path'];
+        $htaccess_path = ABSPATH . '/' . $path . '/.htaccess';
         $htaccess_content = file_get_contents($htaccess_path);
-        $rules = $begin_Comment . "\n";
+        $rules = "\n" . $begin_Comment . "\n";
         // serve the html via PHP
         $path_rules = '<IfModule mod_rewrite.c>' . "\n";
         $path_rules .= 'RewriteEngine On' . "\n";
@@ -32,14 +33,15 @@ function electric_book_wp_htaccess_restricted_paths($action = null, $pathPassed 
         $path_rules .= '<IfModule mod_rewrite.c>' . "\n";
         $path_rules .= 'RewriteEngine On' . "\n";
         $path_rules .= 'RewriteCond %{REQUEST_URI} \.(?:html|htm)$ [NC]' . "\n";
-        $path_rules .= 'RewriteRule . /index.php?electric-book-wp-restricted-path=' . $path['path'] . '&electric-book-wp-serve=%{REQUEST_URI} [L]' . "\n";
+        $path_rules .= 'RewriteRule . /index.php?electric-book-wp-restricted-path=' . $path . '&electric-book-wp-serve=%{REQUEST_URI} [L]' . "\n";
         $path_rules .= '</IfModule>' . "\n";
         $rules .= $path_rules;
-        $rules .= $end_Comment;
+        $rules .= $end_Comment . "\n";
         // Add rules to htaccess file. If one doesn't exist one will be created.
         if (strpos($htaccess_content, $begin_Comment) !== false) {
           $existing_rules = between($begin_Comment, $end_Comment, $htaccess_content);
           $htaccess_content_updated = str_replace($begin_Comment . $existing_rules . $end_Comment, $rules, $htaccess_content);
+          $htaccess_content_updated = str_replace("\n\n", "\n", $htaccess_content);
           file_put_contents($htaccess_path, $htaccess_content_updated);
         } else {
           file_put_contents($htaccess_path, $rules, FILE_APPEND | LOCK_EX);

--- a/wp-content/plugins/electric-book-wp/wp-electric-book.php
+++ b/wp-content/plugins/electric-book-wp/wp-electric-book.php
@@ -36,7 +36,7 @@ function electric_book_wp_settings_init()
 
   add_settings_section(
     'electric_book_wp_section_restrict_access',
-    __('Restrict access to a static file or directory', 'electric_book_wp'),
+    __('Restrict access to a static file directory', 'electric_book_wp'),
     'electric_book_wp_section_restrict_access_cb',
     'electric_book_wp'
   );
@@ -85,14 +85,15 @@ add_action('admin_init', 'electric_book_wp_settings_init');
 // $args is the last parameter defined by add_settings_section()
 function electric_book_wp_section_restrict_access_cb($args)
 { ?>
-  <p>Paths should be relative to the root of your WordPress installation. A path to a directory will automatically include all subdirectories and files inside it.</p>
+  <p>Paths should be relative to the root of your WordPress installation.</p>
 <?php }
 
 // restrict section field callbacks
 // $args is the last parameter defined by add_settings_field()
 function electric_book_wp_field_restrict_path_cb($args)
 { ?>
-  <input id="<?= esc_attr($args['label_for']) ?>" type="text" name="electric_book_wp_restrict[<?= esc_attr($args['label_for']) ?>]" placeholder="your/path/goes/here.html" class="regular-text">
+  <input id="<?= esc_attr($args['label_for']) ?>" type="text" name="electric_book_wp_restrict[<?= esc_attr($args['label_for']) ?>]" placeholder="your/path/goes/here" class="regular-text">
+  <p>Please note, that the entire terminal directory will be restricted. E.g. 'your/path/file.html' will result in the entire 'your/path/' being restricted.</p>
   <?php }
 
 function electric_book_wp_field_restrict_roles_cb($args)
@@ -153,23 +154,18 @@ function electric_book_wp_restrict_options_page_html()
     $restrict_options = get_option('electric_book_wp_restrict');
 
     // get path field
-    $restrict_path_added = $restrict_options[$electric_book_wp_field_path_id];
-    // remove fragment links (don't get passed to server)
-    $restrict_path_added = strtok($restrict_path_added, '#');
-    // remove query params
-    $restrict_path_added = strtok($restrict_path_added, '?');
-    $restrict_path_added = strtok($restrict_path_added, '&');
+    $restrict_path_added = dirname($restrict_options[$electric_book_wp_field_path_id]) == '.' ? $restrict_options[$electric_book_wp_field_path_id] : dirname($restrict_options[$electric_book_wp_field_path_id]);
     // remove leading and trailing slashes
     $restrict_path_added = trim($restrict_path_added, '/');
 
     // check path exists and doesn't coflict with any WP URIs in DB
     $restrict_path_added_abspath = ABSPATH . '/' . $restrict_path_added;
-    $file_folder_exists = file_exists($restrict_path_added_abspath) || is_dir($restrict_path_added_abspath);
+    $folder_exists = is_dir($restrict_path_added_abspath);
     $is_wp_uri = get_page_by_path($restrict_path_added, OBJECT, ['page', 'post']);
 
     $restricted_path_url = get_option('siteurl') . '/' .  $restrict_path_added;
 
-    if (!empty($restrict_path_added) && $file_folder_exists && !$is_wp_uri && filter_var($restricted_path_url, FILTER_VALIDATE_URL)) {
+    if (!empty($restrict_path_added) && $folder_exists && !$is_wp_uri && filter_var($restricted_path_url, FILTER_VALIDATE_URL)) {
       $saved_restricted_roles = array();
       foreach ($restrict_options as $key => $option) {
         if (startsWith($electric_book_wp_field_roles_id, $key)) {


### PR DESCRIPTION
@arthurattwell 

In the service of trying to simplify things, I propose this update. Instead of allowing the restriction of specific files and directories, only allow the latter.

There was actually a bug in the code that meant depending on what order entries were saved, specific files wouldn't be restricted anyway.

This update still doesn't fully explain (to me at least) the issue you shared. The needle/haystack logic shouldn't have resulted in what you shared with me, from best I can tell. So, a good place to (re)start, in my opinion, is to first simplify things, and then go from there.

Hopefully this still meets your requirements.
